### PR TITLE
add release-uuid label to deployments

### DIFF
--- a/lib/releases.js
+++ b/lib/releases.js
@@ -38,7 +38,7 @@ async function auto_releases(pg_pool) {
 }
 
 // private
-async function request_release(pg_pool, app_dest, image) {
+async function request_release(pg_pool, app_dest, image, release_id) {
   let formations = await formation.list_types(pg_pool, app_dest.name, app_dest.space)
   if(formations.length === 0) {
     assert.ok(app_dest.app, 'No uuid found on destination app.');
@@ -60,6 +60,7 @@ async function request_release(pg_pool, app_dest, image) {
     "akkeris.io/app-uuid":app_dest.app,
     "akkeris.io/internal":internal ? "true" : "false",
     "akkeris.io/production":production ? "true" : "false",
+    "akkeris.io/release-uuid":release_id,
   }
   let results = []
   for (let i=0 ; i < formations.length; i++) {
@@ -135,9 +136,10 @@ async function create_release(pg_pool, app_src, app_dest, build_uuid, descriptio
   if(!build) {
     throw new common.ConflictError(`The build id ${build_uuid} does not exist or is still in process of building`)
   }
-  await request_release(pg_pool, app_dest, build.docker_registry_url)
+  let release_id = uuid.v4();
+  await request_release(pg_pool, app_dest, build.docker_registry_url, release_id)
   let release = {
-    id:uuid.v4(),
+    id:release_id,
     app:app_dest.app,
     app_name:app_dest.name,
     space_name:app_dest.space,


### PR DESCRIPTION
Add `akkeris.io/release-uuid` label to deployments when a release is requested. This will help make tracking releases in the apps-watcher more reliable