### PR TITLE
fix duplicate redeploy when app scaled

### DIFF
--- a/lib/formations.js
+++ b/lib/formations.js
@@ -122,9 +122,11 @@ async function update_dyno(pg_pool, app_uuid, app_name, space_name, form) {
     logs.event(pg_pool, app_name, space_name, "Changing startup command on web to default")
     await update_formation_remove_command(pg_pool, [app_uuid, form.type])
     formation[0].command = null;
+    formation[0].needsRedeploy = true;
   }
   if(form.command && form.command !== existing_formation[0].command) {
     logs.event(pg_pool, app_name, space_name, "Changing startup command on " + formation[0].type + " to " + form.command)
+    formation[0].needsRedeploy = true;
   }
   if(typeof (form.quantity) !== 'undefined' && form.quantity !== null) {
     logs.event(pg_pool, app_name, space_name, "Scaling dynos on " + formation[0].type + " to " + form.quantity)
@@ -133,18 +135,22 @@ async function update_dyno(pg_pool, app_uuid, app_name, space_name, form) {
   if(form.port && formation[0].type === 'web') {
     logs.event(pg_pool, app_name, space_name, "Changing application port to " + form.port)
     await common.alamo.dyno.change_port(pg_pool, app_name, space_name, form.port)
+    formation[0].needsRedeploy = true;
   }
   if(form.size) {
     logs.event(pg_pool, app_name, space_name, "Changing dyno plan on " + formation[0].type + " to " + formation[0].size)
     await common.alamo.dyno.change_plan(pg_pool, app_name, space_name, formation[0].type, form.size)
+    formation[0].needsRedeploy = true;
   }
   if(form.healthcheck && formation[0].type === 'web') {
     logs.event(pg_pool, app_name, space_name, "Changing application health check to " + form.healthcheck)
     await common.alamo.dyno.change_healthcheck(pg_pool, app_name, space_name, formation[0].type, form.healthcheck)
+    formation[0].needsRedeploy = true;
   } else if (form.removeHealthcheck && formation[0].type === 'web') {
     logs.event(pg_pool, app_name, space_name, "Removing application health check")
     await update_formation_remove_healthcheck(pg_pool, [app_uuid, form.type])
     await common.alamo.dyno.remove_healthcheck(pg_pool, app_name, space_name, formation[0].type)
+    formation[0].needsRedeploy = true;
   }
   return formation[0];
 }
@@ -277,7 +283,10 @@ async function http_batch_update(pg_pool, req, res, regex) {
   }
   let results = await Promise.all(inbound.map(async (form) => update_dyno(pg_pool, app.app_uuid, app.app_name, app.space_name, form)));
   setTimeout(() => {
-    lifecycle.restart_and_redeploy_app(pg_pool, app.app_uuid, app.app_name, app.space_name, app.org_name, 'Formation Changed').catch(console.error.bind(console))
+    if (results.some(formation => formation.needsRedeploy)) {
+      lifecycle.restart_and_redeploy_app(pg_pool, app.app_uuid, app.app_name, app.space_name, app.org_name, 'Formation Changed').catch(console.error.bind(console))
+    }
+    results.forEach(formation => { delete formation.needsRedeploy; }); // don't need this in the results
     common.notify_hooks(pg_pool, app.app_uuid, 'formation_change', JSON.stringify({
       'action': 'formation_change',
       'app': {


### PR DESCRIPTION
The call to `common.alamo.dyno.scale()` already restarts the app so the call to `lifecycle.restart_and_redeploy_app()` is not needed during a scale 