### PR TITLE
COBRA-3058: add "pipeline_promotion" hook

### DIFF
--- a/docs/API-Reference.md
+++ b/docs/API-Reference.md
@@ -5231,9 +5231,7 @@ This event occurs when an app has a new version and is now available for request
 
 ### Pipeline Promotion Event Payload
 
-This event occurs upon a successful pipeline promotion. It fires on the target apps in the coupling, and includes information about the source app (`promoted_from`) and the new release (`release`).
-
-#### Target App
+This event occurs upon a successful pipeline promotion. It fires on the target apps in the coupling, and includes information about the source app (`promoted_from`), the new release (`release`), and the build (`build`).
 
 `POST [callback end point]`
 
@@ -5256,11 +5254,12 @@ This event occurs upon a successful pipeline promotion. It fires on the target a
       "name":"source-space"
     }
   },
+  "build": {
+    "id":"7edbac4b-6a5e-09e1-ef3a-08084a904621"
+  },
   "release":{
     "id":"1edbac4b-6a5e-09e1-ef3a-08084a904623",
     "status":"queued",
-    "created_at":"2016-08-09T12:00:00Z",
-    "version":13,
     "description":"Promotion from sourceapp-source-space"
   }
 }

--- a/docs/API-Reference.md
+++ b/docs/API-Reference.md
@@ -4766,10 +4766,11 @@ The following events exist for hooks to listen to:
 * preview-released
 * released
 * crashed
+* pipeline_promotion
 
-When a hook is called the URL provided is called with a `POST` method, the body is different depending on the event but will always have the property "action" that equals the event name. 
+When a hook is called, the URL provided is called with a `POST` method. While the body of the `POST` may differ slightly depending on the event, it will always have the property "action" that equals the event name. 
 
-Finally you can rely on the following headers being available on each of the webhook calls:
+Finally, you can rely on the following headers being available on each of the webhook calls:
 
 * `x-akkeris-event` will equal the event name
 * `x-akkeris-delivery` will equal the unique id for the webhook result event.
@@ -5228,6 +5229,42 @@ This event occurs when an app has a new version and is now available for request
 }
 ```
 
+### Pipeline Promotion Event Payload
+
+This event occurs upon a successful pipeline promotion. It fires on the target apps in the coupling, and includes information about the source app (`promoted_from`) and the new release (`release`).
+
+#### Target App
+
+`POST [callback end point]`
+
+```json
+{
+  "action":"pipeline_promotion",
+  "app":{
+    "name":"targetapp",
+    "id":"7edbac4b-6a5e-09e1-ef3a-08084a904621"
+  },
+  "space":{
+    "name":"target-space"
+  },
+  "promoted_from":{
+    "app":{
+      "name":"sourceapp",
+      "id":"7edbac4b-6a5e-09e1-ef3a-08084a904621"
+    },
+    "space":{
+      "name":"source-space"
+    }
+  },
+  "release":{
+    "id":"1edbac4b-6a5e-09e1-ef3a-08084a904623",
+    "status":"queued",
+    "created_at":"2016-08-09T12:00:00Z",
+    "version":13,
+    "description":"Promotion from sourceapp-source-space"
+  }
+}
+```
 
 ## Invoices
 

--- a/lib/hooks.js
+++ b/lib/hooks.js
@@ -116,6 +116,7 @@ function check_hook(hook) {
     "released",
     "preview",
     "preview-released",
+    "pipeline_promotion",
   ];
   assert.ok(hook.events.every((x) => { return allowed_events.indexOf(x) !== -1; }),
     'One of the specified events was invalid.');

--- a/lib/pipelines.js
+++ b/lib/pipelines.js
@@ -495,9 +495,11 @@ async function http_create_pipeline_promotion(pg_pool, req, res, regex) {
           'name': app.space_name,
         },
       },
+      'build': {
+        'id':release.build_uuid,
+      },
       'release': {
         'id': release.release_id,
-        'build': release.build_uuid,
         'status': release.status,
         'description': release.description,
       },

--- a/lib/pipelines.js
+++ b/lib/pipelines.js
@@ -476,6 +476,32 @@ async function http_create_pipeline_promotion(pg_pool, req, res, regex) {
     create_pipeline_promotion_target_query(pg_pool, [pipeline_promotion_target_id, created, created, pipeline_promotion_uuid, release.id, app_dst.app]).catch((err) => {
       console.warn('An error occured trying to create a pipeline promotion target:', err)
     });
+    // Send out a 'pipeline_promotion' hook on the current target app
+    setTimeout(() => common.notify_hooks(pg_pool, target.app_uuid, 'pipeline_promotion', JSON.stringify({
+      'action': 'pipeline_promotion',
+      'app': {
+        'name': target.app_name,
+        'id': target.app_uuid,
+      },
+      'space': {
+        'name': target.space_name,
+      },
+      'promoted_from': {
+        'app': {
+          'name:': app.app_name,
+          'id': app.app_uuid,
+        },
+        'space': {
+          'name': app.space_name,
+        },
+      },
+      'release': {
+        'id': release.release_id,
+        'build': release.build_uuid,
+        'status': release.status,
+        'description': release.description,
+      },
+    }), req.headers['x-username'] ? req.headers['x-username'] : "System"), 10);
   }
 
   return httph.created_response(res, JSON.stringify({


### PR DESCRIPTION
Send a "pipeline_promotion" hook on all target apps in a pipeline coupling upon successful promotion, and include information about the source app and pending release.