### PR TITLE
add TTL_TEMP_TOKEN env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@
 * `BLACKLIST_ENV` - A comma delimited list of socs keywords causing config vars to be redacted, defaults to `PASS,KEY,SECRET,PRIVATE,TOKEN,SALT,AUTH,HASH`
 * `DYNO_DEFAULT_SIZE` - The default dyno size to use. The set default is `gp1` if no other is specified.
 * `RESERVED_SPACES` - A list of reserved spaces to add to the reserved list.  The default reserved spaces are `kube-system, brokers, k2-poc, kube-public, akkeris-system, istio-system, cert-manager`. Note, setting this will only add to the list, not override it.
+* `TTL_TEMP_TOKEN` - How long (in ms) should temporary JWT tokens last for? Defaults to 3600000 (1 hour)
 
 ### Integration Variables
 To disable custom formatting for outgoing webhooks set these to true.

--- a/lib/common.js
+++ b/lib/common.js
@@ -121,7 +121,9 @@ async function http_jwks_uri(jwt_public_cert, pg_pool, req, res) {
   httph.ok_response(res, JSON.stringify(result))
 }
 
-const TTL_TEMP_TOKEN = Number.isInteger(process.env.TTL_TEMP_TOKEN) ? process.env.TTL_TEMP_TOKEN : 60/*sec*/ * 60/*min*/ * 1000; 
+const TTL_TEMP_TOKEN = Number.isInteger(Number.parseInt(process.env.TTL_TEMP_TOKEN, 10))
+  ? Number.parseInt(process.env.TTL_TEMP_TOKEN, 10) : 60/* sec */ * 60/* min */ * 1000;
+
 async function create_temp_jwt_token(pem, username, audience, issuer, elevated_access, metadata = {}) {
   if(!pem || pem === '' || pem.length === 0 || (typeof pem === 'string' && pem.trim() === '')) {
     return null; 

--- a/lib/common.js
+++ b/lib/common.js
@@ -121,7 +121,7 @@ async function http_jwks_uri(jwt_public_cert, pg_pool, req, res) {
   httph.ok_response(res, JSON.stringify(result))
 }
 
-const TTL_TEMP_TOKEN = 60/*sec*/ * 60/*min*/ * 1000; 
+const TTL_TEMP_TOKEN = Number.isInteger(process.env.TTL_TEMP_TOKEN) ? process.env.TTL_TEMP_TOKEN : 60/*sec*/ * 60/*min*/ * 1000; 
 async function create_temp_jwt_token(pem, username, audience, issuer, elevated_access, metadata = {}) {
   if(!pem || pem === '' || pem.length === 0 || (typeof pem === 'string' && pem.trim() === '')) {
     return null; 


### PR DESCRIPTION
The environment variable `TTL_TEMP_TOKEN` specifies how long (in ms) temporary JWT tokens should last. Default is 1hr (3600000ms)