### PR TITLE
return error if allow_origin is invalid

### DIFF
--- a/lib/filters.js
+++ b/lib/filters.js
@@ -76,12 +76,19 @@ function to_filter_data(payload) {
       'One or more allowed headers has an invalid value. Regular expressions are not allowed.');
     assert.ok(!payload.options.expose_headers || payload.options.expose_headers.every((x) => /[A-Za-z0-9\:\-]+/.test(x)), 
       'One or more exposed headers has an invalid value. Regular expressions are not allowed.');
-    assert.ok(payload.options.allow_origin.every((x) => /[A-Za-z0-9\:\*]+/.test(x)), 
-      'One or more allowed origins has an invalid value. Regular expressions are not allowed.');
     assert.ok(!payload.options.max_age || (typeof payload.options.max_age === 'number' && payload.options.max_age > 0), 
       'The max_age parameter must be a positive number');
     assert.ok(!payload.options.allow_credentials || typeof payload.options.allow_credentials === 'boolean', 
       'The allow credentials parameter must be a boolean');
+
+    // https://github.com/istio/istio/blob/48148f5be3c6d84fe1fce8a0491d3c89593145a2/pkg/config/labels/instance.go#L37
+    const invalidOrigins = payload.options.allow_origin.filter((origin) => {
+      origin = origin.replace(/^http(s)?:\/\//,"");
+      return origin === '*' ? false :
+        origin.split('.').some((label) => !(/^[a-zA-Z0-9](?:[-a-z-A-Z0-9]*[a-zA-Z0-9])?$/.test(label)))
+    });
+    assert.ok(invalidOrigins.length === 0, `One or more allowed origins is not a valid domain name: "${invalidOrigins.join('", "')}"`);
+
     if(payload.options.allow_methods) {
       payload.options.allow_methods = payload.options.allow_methods.map((x) => x.toUpperCase())
     }


### PR DESCRIPTION
To validate the "allow_origin" field, Istio [splits the string by the dot separator](https://github.com/istio/istio/blob/48148f5be3c6d84fe1fce8a0491d3c89593145a2/pkg/config/validation/validation.go#L152):

```
parts := strings.Split(domain, ".")
...
for i, label := range parts {
  ...
  if !labels.IsDNS1123Label(label) {
```

and uses the [following regex string](https://github.com/istio/istio/blob/48148f5be3c6d84fe1fce8a0491d3c89593145a2/pkg/config/labels/instance.go#L37) in the IsDNS1123Label validation function:

```
dns1123LabelFmt       = "[a-zA-Z0-9](?:[-a-z-A-Z0-9]*[a-zA-Z0-9])?"
```

so I've basically recreated that validation here.