### PR TITLE
use seconds instead of ms for JWT, other minor fixes

### DIFF
--- a/lib/builds.js
+++ b/lib/builds.js
@@ -2,7 +2,7 @@ const assert = require('assert');
 const crypto = require('crypto');
 const fs = require('fs');
 const uuid = require('uuid');
-const { URL } = require('url');
+const url = require('url');
 const config = require('./config.js');
 const config_var = require('./config-var.js');
 const common = require('./common.js');
@@ -218,7 +218,7 @@ async function request_build_docker(pg_pool, app, app_uuid, space, sha, branch, 
     build_params.gm_registry_auth = config.gm_registry_auth;
   }
   if (sources.toLowerCase().startsWith('docker://')) {
-    const docker_uri = new URL(sources);
+    const docker_uri = new url.URL(sources);
     try {
       assert.ok(docker_uri.pathname.indexOf(':') > -1, 'No tag for the specified docker image was used. Please add a unique tag name.');
       build_params.docker_registry = docker_uri.host + docker_uri.pathname;
@@ -246,7 +246,7 @@ async function create(
   version,
   checksum,
   sha,
-  url,
+  build_url,
   author,
   message,
 ) {
@@ -256,12 +256,12 @@ async function create(
   checksum = checksum || '';
   sha = sha || '';
 
-  if (!url || typeof (url) !== 'string') {
+  if (!build_url || typeof (build_url) !== 'string') {
     throw new common.UnprocessibleEntityError('A "url" field with a valid URI is required, note this can be a data uri with a zip/tar.gz blob of your sources.');
   }
   const build_obj = build_payload_to_obj({
-    auto_build, repo, branch, version, checksum, sha, url,
-  }, app_uuid, url, 'aka', `${app_name}-${space_name}`, org, author, message);
+    auto_build, repo, branch, version, checksum, sha, url: build_url,
+  }, app_uuid, build_url, 'aka', `${app_name}-${space_name}`, org, author, message);
   build_obj.id = uuid.v4();
   build_obj.foreign_build_key = 0;
   const org_build_url = build_obj.url;

--- a/lib/common.js
+++ b/lib/common.js
@@ -96,13 +96,13 @@ async function jwks_verify(pem, intended_issuer, intended_audience, data, signat
     (payload.iss && intended_issuer && payload.iss === intended_issuer) || !intended_issuer || !payload.iss,
     'Unauthorized: issuer is invalid',
   );
-  assert.ok(payload.exp && payload.exp > (new Date()).getTime(), 'Unauthorized: token is expired, or has no "exp" field.');
+  assert.ok(payload.exp && payload.exp > Math.floor((new Date()).getTime() / 1000), 'Unauthorized: token is expired, or has no "exp" field.');
   assert.ok(
     (payload.aud && intended_audience && payload.aud === intended_audience) || !intended_audience || !payload.aud,
     'Unauthorized: audience is invalid',
   );
   assert.ok(
-    (payload.nbf && payload.nbf < (new Date()).getTime()) || !payload.nbf,
+    (payload.nbf && payload.nbf < Math.floor((new Date()).getTime()) / 1000) || !payload.nbf,
     'Unauthorized: token cannot be used yet, now < "nbf" field.',
   );
   return payload;
@@ -146,8 +146,8 @@ async function create_temp_jwt_token(pem, username, audience, issuer, elevated_a
     ele: elevated_access, // do they have elevated access.
     aud: audience, // who this token is intended for. (https://tools.ietf.org/html/rfc7519#section-4.1.3)
     iss: issuer, // who issued this token. (https://tools.ietf.org/html/rfc7519#section-4.1.1)
-    exp: (new Date()).getTime() + TTL_TEMP_TOKEN + 60, // expiration date (https://tools.ietf.org/html/rfc7519#section-4.1.4) - allow 1 minute of drift.
-    nbf: (new Date()).getTime() - 60, // token is not valid before (https://tools.ietf.org/html/rfc7519#section-4.1.5) - allow 1 minute of drift.
+    exp: Math.floor((new Date()).getTime() / 1000) + TTL_TEMP_TOKEN + 60, // expiration date (https://tools.ietf.org/html/rfc7519#section-4.1.4) - allow 1 minute of drift.
+    nbf: Math.floor((new Date()).getTime() / 1000) - 60, // token is not valid before (https://tools.ietf.org/html/rfc7519#section-4.1.5) - allow 1 minute of drift.
     jti: Math.round(Math.random() * (Number.MAX_VALUE - 1)), // Random unique identifier for this temp token. (https://tools.ietf.org/html/rfc7519#section-4.1.7)
   };
   return sign_to_token(await jwks_sign(pem, payload));

--- a/lib/git.js
+++ b/lib/git.js
@@ -1,7 +1,7 @@
 const assert = require('assert');
 const crypto = require('crypto');
 const fs = require('fs');
-const { URL } = require('url');
+const url = require('url');
 const uuid = require('uuid');
 const common = require('./common.js');
 const config = require('./config.js');
@@ -67,7 +67,7 @@ async function remove_webhook_if_needed(app_key, repo, token) {
   if (process.env.TEST_MODE) {
     return;
   }
-  const repo_url = new URL(http_help.clean_forward_slash(repo));
+  const repo_url = new url.URL(http_help.clean_forward_slash(repo));
   const github_hooks_api = `https://api.github.com/repos${repo_url.pathname}/hooks`;
   const github_headers = { 'user-agent': 'akkeris-controller-api', authorization: `token ${token}`, 'x-silent-error': true };
   let hooks = await http_help.request('get', github_hooks_api, github_headers, null);
@@ -91,7 +91,7 @@ async function create_webhook_if_needed(app_key, repo, token, user) {
   if (process.env.TEST_MODE) {
     return { validation_token: 'testing', hook: { created: true }, existing: (token === 'existing') };
   }
-  const repo_url = new URL(http_help.clean_forward_slash(repo));
+  const repo_url = new url.URL(http_help.clean_forward_slash(repo));
   // list webhooks
   const alamo_hook_url = `${config.akkeris_app_controller_url}/apps/${app_key}/builds/auto/github`;
   const github_hooks_api = `https://api.github.com/repos${repo_url.pathname}/hooks`;
@@ -184,7 +184,7 @@ async function create_build_from_scm(pg_pool, app_uuid, repo, branch, token) {
   const app = await common.app_exists(pg_pool, app_uuid);
   const headers = { 'user-agent': 'akkeris-controller-api', 'x-silent-error': true, authorization: `token ${token}` };
 
-  const repo_org_and_name = new URL(http_help.clean_forward_slash(repo));
+  const repo_org_and_name = new url.URL(http_help.clean_forward_slash(repo));
 
   const branch_response = await http_help.request(
     'get', `https://api.github.com/repos${repo_org_and_name.pathname}/branches/${branch}`, headers, null,
@@ -281,7 +281,7 @@ async function push_webhook_received(pg_pool, app, payload) {
     headers.Authorization = `token ${payload.authorization.token}`;
   }
   const response = await http_help.request('get', payload.content_url, headers, null);
-  const url = response.headers.location || payload.content_url;
+  const location_url = response.headers.location || payload.content_url;
   try {
     await builds.create(
       pg_pool,
@@ -296,7 +296,7 @@ async function push_webhook_received(pg_pool, app, payload) {
       payload.head_commit.url,
       'already-validated-auto-build',
       payload.head_commit.id,
-      url,
+      location_url,
       `${payload.head_commit.author.name} ${payload.head_commit.author.username ? `(${payload.head_commit.author.username})` : ''}`,
       payload.head_commit.message,
     );
@@ -395,12 +395,12 @@ async function create_preview_build(pg_pool, rec, payload) {
     headers.Authorization = `token ${payload.authorization.token}`;
   }
   const response = await http_help.request('get', payload.content_url, headers, null);
-  const url = response.headers.location || payload.content_url;
+  const location_url = response.headers.location || payload.content_url;
 
   await builds.create(pg_pool,
     preview_app.app_uuid, preview_app.app_name, preview_app.space_name, preview_app.space_tags, preview_app.org_name,
     payload.authorization.auto_build, payload.repo, payload.source_branch, payload.pull_request.url,
-    'already-validated-auto-build', payload.pull_request.head.sha, url,
+    'already-validated-auto-build', payload.pull_request.head.sha, location_url,
     `${payload.pull_request.user.login}`, payload.pull_request.title);
   console.log(`preview build automatically created for ${preview_app.app_name}-${preview_app.space_name}`);
 }

--- a/lib/hook-types/circleci.js
+++ b/lib/hook-types/circleci.js
@@ -1,7 +1,7 @@
 // Do not include anything from the rest of the project here
 // including common.js.
 
-const { URL } = require('url');
+const url = require('url');
 const https = require('./https.js');
 
 function test(hook_url) {
@@ -23,7 +23,7 @@ function fire(id, hook_url, type, incoming, hmac, headers = {}, token = null) {
       AKKERIS_TEMP_TOKEN: token,
     },
   };
-  const uri = new URL(hook_url);
+  const uri = new url.URL(hook_url);
   headers.authorization = Buffer.from(`${uri.password || uri.searchParams.get('access_token') || uri.searchParams.get('circle-token') || uri.searchParams.get('circle_token') || uri.searchParams.get('token') || uri.searchParams.get('key') || uri.username}:`).toString('base64');
   return https.fire(id, hook_url, type, payload, hmac, headers, token);
 }

--- a/lib/hook-types/opsgenie.js
+++ b/lib/hook-types/opsgenie.js
@@ -1,7 +1,7 @@
 // Do not include anything from the rest of the project here
 // including common.js.
 
-const { URL } = require('url');
+const url = require('url');
 const https = require('./https.js');
 
 function test(hook_url) {
@@ -28,7 +28,7 @@ function fire(id, hook_url, type, incoming, hmac, headers = {}, token = null) {
     message: `${incoming.action} event fired on ${incoming.app.name}-${incoming.space.name}`,
     details: to_string_map(incoming),
   };
-  const uri = new URL(hook_url);
+  const uri = new url.URL(hook_url);
   headers.authorization = `GenieKey ${uri.password || uri.searchParams.get('access_token') || uri.searchParams.get('token') || uri.searchParams.get('key') || uri.username}`;
   return https.fire(id, hook_url, type, payload, hmac, headers, token);
 }

--- a/lib/hook-types/rollbar.js
+++ b/lib/hook-types/rollbar.js
@@ -1,7 +1,7 @@
 // Do not include anything from the rest of the project here
 // including common.js.
 
-const { URL } = require('url');
+const url = require('url');
 const https = require('./https.js');
 
 function test(hook_url) {
@@ -44,7 +44,7 @@ function fire(id, hook_url, type, incoming, hmac, headers = {}, token = null) {
   } else {
     payload.status = 'started';
   }
-  const uri = new URL(hook_url);
+  const uri = new url.URL(hook_url);
   payload.access_token = (uri.password || uri.searchParams.get('access_token') || uri.searchParams.get('token') || uri.searchParams.get('key') || uri.username);
   return https.fire(id, hook_url, type, payload, hmac, headers, token);
 }

--- a/test/temp_token.js
+++ b/test/temp_token.js
@@ -56,8 +56,8 @@ describe('jwt tokens: ensure temporary tokens work appropriately', function () {
       ele: false,
       aud: 'http://localhost:5000', // who this token is intended for. (https://tools.ietf.org/html/rfc7519#section-4.1.3)
       iss: 'http://localhost:5000', // who issued this token. (https://tools.ietf.org/html/rfc7519#section-4.1.1)
-      exp: (new Date()).getTime() - TTL_TEMP_TOKEN * 40, // expiration date (https://tools.ietf.org/html/rfc7519#section-4.1.4)
-      nbf: (new Date()).getTime() - TTL_TEMP_TOKEN * 50, // token is not valid before (https://tools.ietf.org/html/rfc7519#section-4.1.5)
+      exp: Math.floor((new Date()).getTime() / 1000) - TTL_TEMP_TOKEN * 40, // expiration date (https://tools.ietf.org/html/rfc7519#section-4.1.4)
+      nbf: Math.floor((new Date()).getTime() / 1000) - TTL_TEMP_TOKEN * 50, // token is not valid before (https://tools.ietf.org/html/rfc7519#section-4.1.5)
       jti: Math.round(Math.random() * (Number.MAX_VALUE - 1)), // Random unique identifier for this temp token. (https://tools.ietf.org/html/rfc7519#section-4.1.7)
     };
     const token = common.sign_to_token(await common.jwks_sign(private_key, payload));
@@ -82,8 +82,8 @@ describe('jwt tokens: ensure temporary tokens work appropriately', function () {
       ele: false,
       aud: 'http://localhost:5000', // who this token is intended for. (https://tools.ietf.org/html/rfc7519#section-4.1.3)
       iss: 'http://localhost:5000', // who issued this token. (https://tools.ietf.org/html/rfc7519#section-4.1.1)
-      exp: (new Date()).getTime() + TTL_TEMP_TOKEN * 50, // expiration date (https://tools.ietf.org/html/rfc7519#section-4.1.4)
-      nbf: (new Date()).getTime() + TTL_TEMP_TOKEN * 20, // token is not valid before (https://tools.ietf.org/html/rfc7519#section-4.1.5)
+      exp: Math.floor((new Date()).getTime() / 1000) + TTL_TEMP_TOKEN * 50, // expiration date (https://tools.ietf.org/html/rfc7519#section-4.1.4)
+      nbf: Math.floor((new Date()).getTime() / 1000) + TTL_TEMP_TOKEN * 20, // token is not valid before (https://tools.ietf.org/html/rfc7519#section-4.1.5)
       jti: Math.round(Math.random() * (Number.MAX_VALUE - 1)), // Random unique identifier for this temp token. (https://tools.ietf.org/html/rfc7519#section-4.1.7)
     };
     const token = common.sign_to_token(await common.jwks_sign(private_key, payload));
@@ -108,8 +108,8 @@ describe('jwt tokens: ensure temporary tokens work appropriately', function () {
       ele: false,
       aud: 'http://localhost:5000', // who this token is intended for. (https://tools.ietf.org/html/rfc7519#section-4.1.3)
       iss: 'http://nope:5000', // who issued this token. (https://tools.ietf.org/html/rfc7519#section-4.1.1)
-      exp: (new Date()).getTime() + TTL_TEMP_TOKEN * 50, // expiration date (https://tools.ietf.org/html/rfc7519#section-4.1.4)
-      nbf: (new Date()).getTime() + TTL_TEMP_TOKEN * 20, // token is not valid before (https://tools.ietf.org/html/rfc7519#section-4.1.5)
+      exp: Math.floor((new Date()).getTime() / 1000) + TTL_TEMP_TOKEN * 50, // expiration date (https://tools.ietf.org/html/rfc7519#section-4.1.4)
+      nbf: Math.floor((new Date()).getTime() / 1000) + TTL_TEMP_TOKEN * 20, // token is not valid before (https://tools.ietf.org/html/rfc7519#section-4.1.5)
       jti: Math.round(Math.random() * (Number.MAX_VALUE - 1)), // Random unique identifier for this temp token. (https://tools.ietf.org/html/rfc7519#section-4.1.7)
     };
     const token = common.sign_to_token(await common.jwks_sign(private_key, payload));
@@ -134,8 +134,8 @@ describe('jwt tokens: ensure temporary tokens work appropriately', function () {
       ele: false,
       aud: 'http://nope:5000', // who this token is intended for. (https://tools.ietf.org/html/rfc7519#section-4.1.3)
       iss: 'http://localhost:5000', // who issued this token. (https://tools.ietf.org/html/rfc7519#section-4.1.1)
-      exp: (new Date()).getTime() + TTL_TEMP_TOKEN * 50, // expiration date (https://tools.ietf.org/html/rfc7519#section-4.1.4)
-      nbf: (new Date()).getTime() + TTL_TEMP_TOKEN * 20, // token is not valid before (https://tools.ietf.org/html/rfc7519#section-4.1.5)
+      exp: Math.floor((new Date()).getTime() / 1000) + TTL_TEMP_TOKEN * 50, // expiration date (https://tools.ietf.org/html/rfc7519#section-4.1.4)
+      nbf: Math.floor((new Date()).getTime() / 1000) + TTL_TEMP_TOKEN * 20, // token is not valid before (https://tools.ietf.org/html/rfc7519#section-4.1.5)
       jti: Math.round(Math.random() * (Number.MAX_VALUE - 1)), // Random unique identifier for this temp token. (https://tools.ietf.org/html/rfc7519#section-4.1.7)
     };
     const token = common.sign_to_token(await common.jwks_sign(private_key, payload));


### PR DESCRIPTION
RFC 7519 says to use seconds instead of miliseconds for JWT expiry calculations.
See https://tools.ietf.org/html/rfc7519#section-2 (NumericDate)

Also change `const { URL } = require('url');` back to `const url = require('url')'` so there is no ambiguity with the Javascript URL object

Tests passing :) 