### PR TITLE
add "release" field to provided "latest_release"

### DIFF
--- a/lib/pipelines.js
+++ b/lib/pipelines.js
@@ -486,6 +486,7 @@ async function http_create_pipeline_promotion(pg_pool, req, res /* regex */) {
   let latest_release = null;
   if (payload.source.app.release && payload.source.app.release.id) {
     latest_release = await common.release_exists(pg_pool, payload.source.app.id, payload.source.app.release.id);
+    latest_release.release = latest_release.id;
   } else {
     latest_release = await common.latest_release(pg_pool, app.app_uuid);
   }


### PR DESCRIPTION
Add `release` field to the `latest_release` object returned by `common.release_exists`. 

The absence of this field means that when a non-elevated access user supplies a specific release ID to promote (which always happens on the UI) the later call to `select_release_statuses` will always return null. This means that the controller will always think that there are no successful statuses and will always fail the promote.

This doesn't happen for elevated access users because the default behavior is to override status checks -
```
if (failures.length !== 0 && !(payload.safe === false && is_elevated_access)) 
```
this behavior should probably be "ignore failures if a user has elevated access and the safe flag is false"