### PR TITLE
COBRA-3835: Reopen expired preview app on push

### DIFF
--- a/lib/git.js
+++ b/lib/git.js
@@ -314,7 +314,7 @@ async function should_create_preview_app(pg_pool, app, payload) {
   }
   // ensure we don't build a new preview app unless new code has arrived, ignore comments,
   // assignments, labels, reviews, title changes, etc.
-  if (payload.action !== 'opened' && payload.action !== 'reopened' && payload.action !== 'edited') {
+  if (payload.action !== 'opened' && payload.action !== 'reopened' && payload.action !== 'edited' && payload.action !== 'synchronize') {
     return false;
   }
   // Ensure an edit action has the same target branch.
@@ -553,7 +553,7 @@ async function add_status(token, org_repo, ref, state, target_url, description) 
   }
 }
 
-// IMPORTANT: Before modifying this behavior read above about how were semi-misusing github's deployment
+// IMPORTANT: Before modifying this behavior read the comment on the create_deployment function about how were semi-misusing github's deployment
 // features, this may cause unintended side affects if you modify the behavior of how this works.
 async function create_deployment_status(
   token,

--- a/lib/git.js
+++ b/lib/git.js
@@ -553,8 +553,8 @@ async function add_status(token, org_repo, ref, state, target_url, description) 
   }
 }
 
-// IMPORTANT: Before modifying this behavior read the comment on the create_deployment function about how were semi-misusing github's deployment
-// features, this may cause unintended side affects if you modify the behavior of how this works.
+// IMPORTANT: Before modifying this behavior read the comment on the create_deployment function about how were semi-misusing
+// github's deployment features, this may cause unintended side affects if you modify the behavior of how this works.
 async function create_deployment_status(
   token,
   org_repo,


### PR DESCRIPTION
When new code is pushed to an open PR, GH sends a `push` webhook and a `pull_request` webhook. We can use the `pull_request` webhook to open a new preview app, but it has an action of `synchronize` that would need to be allowed.