### PR TITLE
Add command aliases

### DIFF
--- a/docs/Dynos.md
+++ b/docs/Dynos.md
@@ -135,17 +135,25 @@ curl \
 
 ### Dyno Attach
 
-Executes (white listed) commands on a dyno, the provided command is ran on the same server under the same context under the same memory and CPU limitations. The output of the stdout and stderr is returned. An error is returned if the command takes more than one minute. 
+Executes approved commands on a dyno. The provided command is run in the same context as the dyno, and is subject to the same memory and CPU limitations. The output of stdout and stderr is returned.
 
-White listed commands are hard coded and cannot be changed dynamically.  The current white list is:
+> Please note that an error is returned if the command takes more than one minute.
+
+Allowed commands are hardcoded and cannot be changed dynamically. The current regex allowlist is:
 
 * `/^sh -c kill \-[0-9]+ \-1$/`
+
+Alternatively, you may specify a command alias instead of a command. This is useful for certain complicated commands that don't need any arguments and will be run the same way each time. These commands are also hardcoded and cannot be changed dynamically. The available aliases are:
+
+* `java_heap_dump` - Run `jcmd 0 GC.heap_dump` and return the output as a base64/gzip encoded string.
+  * Here's an example of how to transform the results into a file for further analysis (assuming the API response was stored in `response.json`): `cat response.json | jq -r '.stdout' | base64 -D | gzip -d > heap_dump.hprof`
 
 `POST /apps/{appname}/dynos/{dyno_id_or_name}/actions/attach`
 
 |   Name   |       Type      | Description                                                                                                                                                                                                | Example                                                                                                                            |
 |:--------:|:---------------:|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------------------------------------------------------------------------------------------------------------------------------|
-|   command      | required array of strings | The command to execute (as an array of strings where the first entry is the executable) |  ["echo", "hello"] |
+|   command      | optional array of strings | The command to execute (as an array of strings where the first entry is the executable) (*Required if `alias` is not provided*) |  ["echo", "hello"] |
+|   alias      | optional string | The alias of a pre-validated command to execute (*Required if `command` is not provided*) | "java_heap_dump" |
 |   stdin        | string | The initial set of stdin  | "" |
 
 

--- a/lib/dynos.js
+++ b/lib/dynos.js
@@ -198,9 +198,20 @@ async function http_restart_dyno(pg_pool, req, res, regex) {
   return httph.ok_response(res, JSON.stringify({ status: 'pending', type: info[0], dyno: info[1] }));
 }
 
-const execute_whitelist = [
+// These are the regex filters for allowed commands
+const execute_allowlist = [
   /^sh -c kill -[0-9]+ -1$/,
 ];
+
+// These pre-validated complicated commands can be run by specifying their "alias" name
+const execute_aliases = {
+  // Return java heap dump as a base64 encoded gzip string
+  java_heap_dump: [
+    '/bin/sh',
+    '-c',
+    "rm -f dump.hprof.gz >/dev/null 2>&1; jcmd 0 GC.heap_dump -gz=1 dump.hprof.gz > jcmd.log 2>&1; if [[ -f \"./dump.hprof.gz\" && -s \"./dump.hprof.gz\" ]]; then base64 dump.hprof.gz | tr -d '\n'; else cat jcmd.log; fi; rm -f dump.hprof.gz jcmd.log >/dev/null 2>&1",
+  ],
+};
 
 // public
 async function http_attach_dyno(pg_pool, req, res, regex) {
@@ -223,10 +234,24 @@ async function http_attach_dyno(pg_pool, req, res, regex) {
     throw new common.NotFoundError('The specified dyno was not found.');
   }
   const akkeris_instance_id = `${app.app_name}-${dyno_type === 'web' ? '' : (`-${dyno_type}`)}${dyno_id}`;
-  const passed = execute_whitelist.filter((x) => x.test(payload.command.join(' '))).length > 0;
-  if (!passed) {
+
+  if (payload.alias && payload.command) {
+    throw new common.BadRequestError('Please specify either an alias OR a command');
+  }
+
+  // If alias was provided, make sure it's valid
+  if (payload.alias && !Object.keys(execute_aliases).find((alias) => alias === payload.alias)) {
+    throw new common.NotAllowedError('Invalid command alias');
+  }
+
+  // If command was provided, validate command against the allow list
+  if (payload.command && execute_allowlist.filter((x) => x.test(payload.command.join(' '))).length <= 0) {
     throw new common.NotAllowedError();
   }
+
+  // Full command to be run (either user-specified or expanded alias)
+  const cmd = payload.command ? payload.command : execute_aliases[payload.alias];
+
   const user = req.headers['x-username'] || 'System';
   common.notify_audits(JSON.stringify({
     action: 'dyno-attachment',
@@ -237,16 +262,21 @@ async function http_attach_dyno(pg_pool, req, res, regex) {
     space: {
       name: app.space_name,
     },
-    command: payload.command,
+    command: cmd,
     stdin: payload.stdin,
     dyno: {
       type: dyno_type,
       id: dyno_id,
     },
   }), user);
-  await common.log_event(pg_pool, app.app_name, app.space_name, `Command "${payload.command.join(' ')} was executed on ${dyno_key} by ${user}`);
+  await common.log_event(
+    pg_pool,
+    app.app_name,
+    app.space_name,
+    `${payload.alias ? `Alias "${payload.alias}"` : `Command "${cmd.join(' ')}"`} was executed on ${dyno_key} by ${user}`,
+  );
   return httph.ok_response(res, JSON.stringify(await common.alamo.dyno.attach(
-    pg_pool, app.space_name, app.app_name, dyno_type, akkeris_instance_id, payload.command, payload.stdin,
+    pg_pool, app.space_name, app.app_name, dyno_type, akkeris_instance_id, cmd, payload.stdin,
   )));
 }
 


### PR DESCRIPTION
Add ability to specify a command alias that will run a pre-validated command on a dyno

Add `java_heap_dump` alias that will run `jcmd 0 GC.heap_dump` and return the results in base64/gzip