### PR TITLE
fix heap dump command

### DIFF
--- a/lib/dynos.js
+++ b/lib/dynos.js
@@ -209,7 +209,7 @@ const execute_aliases = {
   java_heap_dump: [
     '/bin/sh',
     '-c',
-    "rm -f dump.hprof.gz >/dev/null 2>&1; jcmd 0 GC.heap_dump -gz=1 dump.hprof.gz > jcmd.log 2>&1; if [[ -f \"./dump.hprof.gz\" && -s \"./dump.hprof.gz\" ]]; then base64 dump.hprof.gz | tr -d '\n'; else cat jcmd.log; fi; rm -f dump.hprof.gz jcmd.log >/dev/null 2>&1",
+    "rm -f dump.hprof >/dev/null 2>&1; jcmd 0 GC.heap_dump dump.hprof > jcmd.log 2>&1; if [ -f \"./dump.hprof\" ] && [ -s \"./dump.hprof\" ] ; then cat dump.hprof | gzip | base64 | tr -d '\n'; else cat jcmd.log; fi; rm -f dump.hprof jcmd.log >/dev/null 2>&1",
   ],
 };
 


### PR DESCRIPTION
gzip not supported option on jdk < 15, so do it manually.

Also make sure that `/bin/sh` is supported (not just `bash`)