### PR TITLE
COBRA-3939: Allow port number on CORS filter allowed origins

### DIFF
--- a/lib/filters.js
+++ b/lib/filters.js
@@ -82,7 +82,7 @@ function to_filter_data(payload) {
     const invalidOrigins = payload.options.allow_origin.filter((origin) => {
       origin = origin.replace(/^http(s)?:\/\//, '');
       return origin === '*' ? false
-        : origin.split('.').some((label) => !(/^[a-zA-Z0-9](?:[-a-z-A-Z0-9]*[a-zA-Z0-9])?$/.test(label)));
+        : origin.split('.').some((label) => !(/^[a-zA-Z0-9](?:[-a-z-A-Z0-9]*[a-zA-Z0-9])?(?::[0-9]+)?$/.test(label)));
     });
     assert.ok(invalidOrigins.length === 0, `One or more allowed origins is not a valid domain name: "${invalidOrigins.join('", "')}"`);
 

--- a/test/filters.js
+++ b/test/filters.js
@@ -20,6 +20,7 @@ describe('filters: ensure filters can be created and applied.', function () {
   let testapp_filter = null;
   let testapp_filter2 = null;
   let testapp_filter3 = null;
+  let testapp_filter4 = null;
   let testapp_filter_attachment = null;
   let testapp_filter_attachment2 = null;
 
@@ -135,6 +136,11 @@ describe('filters: ensure filters can be created and applied.', function () {
     expect(testapp_filter3.organization).to.be.an('object');
     expect(testapp_filter3.organization.id).to.be.a('string');
     expect(testapp_filter3.id).to.be.a('string');
+
+    payload.name = 'test-filter-name4';
+    payload.options.allow_origin = ['https://www.octanner.app', 'http://localhost:3000'];
+    testapp_filter4 = JSON.parse(await httph.request('post', 'http://localhost:5000/filters', alamo_headers, JSON.stringify(payload)));
+    expect(testapp_filter4.options.allow_origin).to.eql(['https://www.octanner.app', 'http://localhost:3000']);
   });
 
   it('ensure invalid values are not allowed in cors filters', async () => {
@@ -420,6 +426,7 @@ describe('filters: ensure filters can be created and applied.', function () {
     await httph.request('delete', 'http://localhost:5000/filters/test-filter-name', alamo_headers, null);
     await httph.request('delete', 'http://localhost:5000/filters/test-filter-name2', alamo_headers, null);
     await httph.request('delete', 'http://localhost:5000/filters/test-filter-name3', alamo_headers, null);
+    await httph.request('delete', 'http://localhost:5000/filters/test-filter-name4', alamo_headers, null);
   });
 
   it('delete: clean up after ourselves', async () => {


### PR DESCRIPTION
This will now accept allowed origins that include port numbers, such as `http://localhost:3000`.