### PR TITLE
COBRA-3940: Return attached apps on filters show

### DIFF
--- a/lib/filters.js
+++ b/lib/filters.js
@@ -104,8 +104,18 @@ function to_filter_data(payload) {
   return null;
 }
 
+function attached_apps_response(payload) {
+  return {
+    name: payload.app_name,
+    space: {
+      name: payload.space_name,
+    },
+  };
+}
+
 const select_filters = query.bind(query, fs.readFileSync('./sql/select_filters.sql').toString('utf8'), filter_to_response);
 const select_filter = query.bind(query, fs.readFileSync('./sql/select_filter.sql').toString('utf8'), filter_to_response);
+const select_attached_apps = query.bind(query, fs.readFileSync('./sql/select_attached_apps.sql').toString('utf8'), attached_apps_response);
 const delete_filter = query.bind(query, fs.readFileSync('./sql/delete_filter.sql').toString('utf8'), filter_to_response);
 const create_filter = query.bind(query, fs.readFileSync('./sql/insert_filter.sql').toString('utf8'), filter_to_response);
 const update_filter = query.bind(query, fs.readFileSync('./sql/update_filter.sql').toString('utf8'), filter_to_response);
@@ -128,6 +138,8 @@ async function http_filters_get(pg_pool, req, res, regex) {
   if (filters.length === 0) {
     throw new common.NotFoundError('The specified filter was not found.');
   }
+  const attached_apps = await select_attached_apps(pg_pool, [filter_key]);
+  filters[0].attached_apps = attached_apps;
   return httph.ok_response(res, JSON.stringify(filters[0]));
 }
 

--- a/sql/select_attached_apps.sql
+++ b/sql/select_attached_apps.sql
@@ -1,0 +1,8 @@
+select
+	apps.name as app_name,
+	spaces.name as space_name
+from filters
+	join filter_attachments on filters.filter = filter_attachments.filter and filter_attachments.deleted = false
+	join apps on filter_attachments.app = apps.app and apps.deleted = false
+	join spaces on apps.space = spaces.space and spaces.deleted = false
+where filters.deleted = false and (filters.name = $1 or filters.filter::varchar(1024) = $1)

--- a/test/filters.js
+++ b/test/filters.js
@@ -187,7 +187,7 @@ describe('filters: ensure filters can be created and applied.', function () {
     expect(filter.id).to.be.a('string');
   });
 
-  it('get a filter', async () => {
+  it('get a filter with no attachments', async () => {
     const filter = JSON.parse(await httph.request('get', 'http://localhost:5000/filters/test-filter-name', alamo_headers, null));
     expect(filter).to.be.an('object');
     expect(filter.name).to.equal('test-filter-name');
@@ -200,6 +200,7 @@ describe('filters: ensure filters can be created and applied.', function () {
     expect(filter.organization).to.be.an('object');
     expect(filter.organization.id).to.be.a('string');
     expect(filter.id).to.be.a('string');
+    expect(filter.attached_apps).to.eql([]);
   });
 
   it('update a filter', async () => {
@@ -389,6 +390,24 @@ describe('filters: ensure filters can be created and applied.', function () {
     expect(fa.filter.id).to.equal(testapp_filter.id);
     expect(fa.created_at).to.be.a('string');
     expect(fa.updated_at).to.be.a('string');
+  });
+
+  it('get a filter with attachments', async () => {
+    const filter = JSON.parse(await httph.request('get', `http://localhost:5000/filters/${testapp_filter.id}`, alamo_headers, null));
+    expect(filter).to.be.an('object');
+    expect(filter.name).to.equal('test-filter-name');
+    expect(filter.description).to.equal('second desc');
+    expect(filter.type).to.equal('jwt');
+    expect(filter.options.jwks_uri).to.equal('https://foobar2.com');
+    expect(filter.options.issuer).to.equal('fooissuer2');
+    expect(filter.created_at).to.be.a('string');
+    expect(filter.updated_at).to.be.a('string');
+    expect(filter.organization).to.be.an('object');
+    expect(filter.organization.id).to.be.a('string');
+    expect(filter.id).to.be.a('string');
+    expect(filter.attached_apps).to.be.an('array').of.length(1);
+    expect(filter.attached_apps[0].name).to.match(/alamotest\n*/);
+    expect(filter.attached_apps[0].space).to.eql({ name: 'default' });
   });
 
   it('delete filter attachments on an app', async () => {


### PR DESCRIPTION
See the `attached_apps` on this sample response:

```json
curl http://localhost:5000/filters/somecorsfilter -H "Authorization: obert" | jq
{
  "created_at": "2020-01-17T16:36:31.960Z",
  "description": "Test CORS filter",
  "id": "f963e89d-9c53-f9e4-65ab-984a2d2386d2",
  "options": { },
  "name": "somecorsfilter",
  "type": "cors",
  "organization": {
    "id": "0b26ccb5-83cc-4d33-a01f-100c383e0066"
  },
  "updated_at": "2020-12-03T20:49:45.845Z",
  "attached_apps": [
    {
      "name": "robots",
      "space": {
        "name": "calaway"
      }
    },
    {
      "name": "taas",
      "space": {
        "name": "calaway"
      }
    }
  ]
}
```