### PR TITLE
Fix Kafka topic ACLs being bound in the wrong region

### DIFF
--- a/lib/topic_acls.js
+++ b/lib/topic_acls.js
@@ -51,7 +51,7 @@ async function create(pg_pool, req, res, regex) {
   const payload = await httph.buffer_json(req);
 
   const cluster_key = httph.first_match(req.url, regex);
-  const { name: cluster_name, cluster: cluster_uuid, region_name } = await common.cluster_exists(pg_pool, cluster_key);
+  const { name: cluster_name, cluster: cluster_uuid } = await common.cluster_exists(pg_pool, cluster_key);
 
   const topic_key = httph.second_match(req.url, regex);
   const { topic: topic_uuid, name: topic_name } = await common.topic_exists(pg_pool, topic_key, cluster_uuid);
@@ -60,7 +60,11 @@ async function create(pg_pool, req, res, regex) {
     throw new common.UnprocessibleEntityError('The specified request contained an invalid "app" field.');
   }
 
-  const { app_uuid, app_name, space_name } = await common.app_exists(pg_pool, payload.app);
+  // Need to use region of app instead of region of cluster
+  // This is so we create the bind on the correct region-api
+  const {
+    app_uuid, app_name, space_name, region_name,
+  } = await common.app_exists(pg_pool, payload.app);
 
   const { role } = payload;
   if (!role) {
@@ -87,7 +91,7 @@ async function create(pg_pool, req, res, regex) {
 
 async function remove(pg_pool, req, res, regex) {
   const cluster_key = httph.first_match(req.url, regex);
-  const { region_name } = await common.cluster_exists(pg_pool, cluster_key);
+  let { region_name } = await common.cluster_exists(pg_pool, cluster_key);
   const topic_key = httph.second_match(req.url, regex);
   const acl_key = httph.third_match(req.url, regex);
   const { topic: topic_uuid } = await common.topic_exists(pg_pool, topic_key, cluster_key);
@@ -98,7 +102,10 @@ async function remove(pg_pool, req, res, regex) {
     acl_id = acl_key;
   } else {
     // ACL key could be an app name.
-    const { app_uuid } = await common.app_exists(pg_pool, acl_key);
+    const { app_uuid, region_name: app_region } = await common.app_exists(pg_pool, acl_key);
+
+    // Use the app region rather than the cluster region so we remove the bind from the correct region-api
+    region_name = app_region;
 
     const acls = await select_acl_by_app_and_topic_and_role(pg_pool, [app_uuid, topic_uuid, role]);
     if (!acls || acls.length === 0) {
@@ -117,7 +124,7 @@ async function remove(pg_pool, req, res, regex) {
 
 async function remove_consumer(pg_pool, req, res, regex) {
   const cluster_key = httph.first_match(req.url, regex);
-  const { region_name } = await common.cluster_exists(pg_pool, cluster_key);
+  let { region_name } = await common.cluster_exists(pg_pool, cluster_key);
   const topic_key = httph.second_match(req.url, regex);
   const acl_key = httph.third_match(req.url, regex);
   const { topic: topic_uuid } = await common.topic_exists(pg_pool, topic_key, cluster_key);
@@ -129,7 +136,10 @@ async function remove_consumer(pg_pool, req, res, regex) {
     acl_id = acl_key;
   } else {
     // ACL key could be an app name.
-    const { app_uuid } = await common.app_exists(pg_pool, acl_key);
+    const { app_uuid, region_name: app_region } = await common.app_exists(pg_pool, acl_key);
+
+    // Use the app region rather than the cluster region so we remove the bind from the correct region-api
+    region_name = app_region;
 
     const acls = await select_acl_by_app_and_topic_and_role_and_consumergroup(
       pg_pool,

--- a/lib/topics.js
+++ b/lib/topics.js
@@ -4,7 +4,6 @@ const common = require('./common.js');
 const httph = require('./http_helper.js');
 const query = require('./query.js');
 
-
 // private
 function topic_to_response(db_topic, system_topic) {
   return {
@@ -200,7 +199,6 @@ async function recreate(pg_pool, req, res, regex) {
   await common.alamo.topics.delete(region_name, cluster_name, name);
   await delete_acl_by_topic(pg_pool, [db_topic_before.topic]);
 
-
   await new Promise((r) => setTimeout(r, 5000));
 
   // recreate the topic
@@ -239,7 +237,7 @@ async function recreate(pg_pool, req, res, regex) {
       id,
       consumerGroupName,
     } = await common.alamo.topic_acls.create(
-      region_name,
+      acl.region_name, // Region of app, not region of cluster
       cluster_name,
       name,
       acl.app_name,
@@ -253,7 +251,7 @@ async function recreate(pg_pool, req, res, regex) {
   // recreate key mappings
   if (system_topic_before.keyMapping) {
     await common.alamo.topic_schemas.create_key_mapping(
-      region_name,
+      region_name, // Region of cluster
       cluster_name,
       name,
       system_topic_before.keyMapping.keyType,

--- a/sql/select_topic_acls_by_topic.sql
+++ b/sql/select_topic_acls_by_topic.sql
@@ -4,6 +4,7 @@ select
   topic_acls.app,
   apps.name as app_name,
   spaces.name as space_name,
+  regions.name as region_name,
   topics.topic,
   topics.name as topic_name,
   topics.cluster,
@@ -14,6 +15,8 @@ select
 from topic_acls
 join apps on (topic_acls.app = apps.app)
 join spaces on (spaces.space = apps.space)
+join stacks on (spaces.stack = stacks.stack and stacks.deleted = false)
+join regions on (regions.region = stacks.region and regions.deleted = false)
 join topics on (topic_acls.topic = topics.topic)
 where
   (topic_acls.topic::varchar(128) = $1) and


### PR DESCRIPTION
Currently, when creating an ACL for an app/topic, we create the binding in the region of the Kafka cluster. This causes an issue when the app is in a different region than the cluster. 

So, we need to use the region of the app, not the region of the cluster, during ACL creation so that the bind is created in the correct region-api.