### PR TITLE
options should default to {}

### DIFF
--- a/lib/formations.js
+++ b/lib/formations.js
@@ -268,7 +268,7 @@ async function create(
   remove_health_check,
   user = 'System',
   oneoff = false,
-  options,
+  options = {},
 ) {
   assert.ok(app_uuid, 'The app uuid was not passed into create formations.');
   assert.ok(type, 'The type was not passed in to formations create.');


### PR DESCRIPTION
One-off options should default to `{}` otherwise we get an error trying to insert records into the formations table