### PR TITLE
COBRA-4159: Build out actions create endpoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ const { simple_key, jwt_key } = require('./lib/auth.js')(config.simple_key, conf
 const common = require('./lib/common.js');
 
 const alamo = {
+  actions: require('./lib/actions.js'),
   addon_attachments: require('./lib/addon-attachments.js'),
   addon_services: require('./lib/addon-services.js'),
   addons: require('./lib/addons.js'),
@@ -824,6 +825,11 @@ routes.add.get('/docs/recommendation_resource_types$')
   .and.authorization([simple_key, jwt_key]);
 routes.add.post('/apps/([A-z0-9\\-\\_\\.]+)/recommendations$')
   .run(alamo.recommendations.http.create.bind(alamo.recommendations.http.create, pg_pool))
+  .and.authorization([simple_key, jwt_key]);
+
+// -- actions
+routes.add.post('/apps/([A-z0-9\\-\\_\\.]+)/actions$')
+  .run(alamo.actions.http.create.bind(alamo.actions.http.create, pg_pool))
   .and.authorization([simple_key, jwt_key]);
 
 routes.add.default((req, res) => {

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -1,0 +1,57 @@
+const fs = require('fs');
+const uuid = require('uuid');
+
+const common = require('./common');
+const formations = require('./formations');
+const http_helper = require('./http_helper');
+const query = require('./query');
+
+// private
+const insert_action = query.bind(query, fs.readFileSync('sql/insert_action.sql').toString('utf8'), (result) => result);
+async function http_create(pg_pool, req, res, regex) {
+  const app_key = http_helper.first_match(req.url, regex);
+  const app = await common.app_exists(pg_pool, app_key);
+  const space = await common.space_exists(pg_pool, app.space_name);
+  const payload = await http_helper.buffer_json(req);
+  const formation_type = `actions${payload.name}`;
+
+  // Create a one-off formation
+  const formation = await formations.create(
+    pg_pool,
+    app.app_uuid,
+    app.app_name,
+    app.space_name,
+    space.tags,
+    app.org_name,
+    formation_type,
+    payload.size,
+    1,
+    payload.command,
+    null,
+    null,
+    false,
+    'System',
+    true,
+    payload.options,
+  );
+
+  // Insert an action into the DB
+  const id = uuid.v4();
+  const created_by = req.headers['x-username'] || 'Unknown';
+  const actions_params = [
+    id,
+    app.app_uuid,
+    formation.id,
+    payload.name,
+    payload.description || '',
+    created_by,
+  ];
+  const actions = await insert_action(pg_pool, actions_params);
+  return http_helper.created_response(res, actions);
+}
+
+module.exports = {
+  http: {
+    create: http_create,
+  },
+};

--- a/sql/create.sql
+++ b/sql/create.sql
@@ -645,6 +645,19 @@ begin
     primary key (app, service, resource_type, action) -- We only store the latest recommendation for the app, service, resource_type, and action
   );
 
+  create table if not exists actions
+  (
+    action uuid not null primary key,
+    app uuid not null references apps("app"),
+    formation uuid not null references formations("formation"),
+    name alpha_numeric not null,
+    description varchar(1024) not null default '',
+    created_by varchar(1024) not null default '',
+    created timestamptz not null default now(),
+    updated timestamptz not null default now(),
+    deleted boolean not null default false
+  );
+
   -- create default regions and stacks
   if (select count(*) from regions where deleted = false) = 0 then
     insert into regions

--- a/sql/insert_action.sql
+++ b/sql/insert_action.sql
@@ -1,0 +1,5 @@
+insert into actions
+  (action, app, formation, name, description, created_by)
+values
+  ($1, $2, $3, $4, $5, $6)
+returning *

--- a/test/actions.js
+++ b/test/actions.js
@@ -1,0 +1,61 @@
+const { expect } = require('chai');
+const http_helper = require('../lib/http_helper.js');
+
+describe('Actions', () => {
+  process.env.AUTH_KEY = 'hello';
+  const init = require('./support/init.js');
+  const config = require('../lib/config.js');
+
+  const akkeris_headers = {
+    Authorization: process.env.AUTH_KEY,
+    'User-Agent': 'Hello',
+    'x-username': 'Calaway',
+    'Content-type': 'application/json',
+  };
+
+  // Nested describe block needed for correct execution order of before/after hooks
+  describe('', async () => {
+    let testapp;
+
+    before(async () => {
+      testapp = await init.create_test_app('default');
+    });
+
+    after(async () => {
+      await init.remove_app(testapp);
+    });
+
+    it('create a new action', async () => {
+      const payload = {
+        name: 'testaction',
+        description: 'This action runs a Docker container and then exits.',
+      };
+      const actions = await http_helper.request('post', `http://localhost:5000/apps/${testapp.name}/actions`, akkeris_headers, payload);
+
+      const test_action = JSON.parse(actions)[0];
+      const uuid_regex = /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/;
+      expect(test_action.action).to.match(uuid_regex);
+      expect(test_action.app).to.equal(testapp.id);
+      expect(test_action.formation).to.match(uuid_regex);
+      expect(test_action.name).to.equal('testaction');
+      expect(test_action.description).to.equal('This action runs a Docker container and then exits.');
+      expect(test_action.created_by).to.equal('Calaway');
+      expect(Date.now() - Date.parse(test_action.created)).to.be.lessThan(60);
+      expect(Date.now() - Date.parse(test_action.updated)).to.be.lessThan(60);
+      expect(test_action.deleted).to.equal(false);
+
+      const formations = await http_helper.request('get', `http://localhost:5000/apps/${testapp.name}/formation`, akkeris_headers);
+      const one_off_formation = JSON.parse(formations).find((f) => f.type !== 'web');
+      expect(one_off_formation.app.id).to.equal(testapp.id);
+      expect(one_off_formation.id).to.match(uuid_regex);
+      expect(one_off_formation.type).to.equal('actionstestaction');
+      expect(one_off_formation.quantity).to.equal(1);
+      expect(one_off_formation.size).to.equal(config.dyno_default_size);
+      expect(one_off_formation.command).to.equal(null);
+      expect(one_off_formation.port).to.equal(null);
+      expect(one_off_formation.healthcheck).to.equal(null);
+      expect(Date.now() - Date.parse(one_off_formation.created_at)).to.be.lessThan(60);
+      expect(Date.now() - Date.parse(one_off_formation.updated_at)).to.be.lessThan(60);
+    });
+  });
+});


### PR DESCRIPTION
User story:
```
- As a developer
- When I create an app
- And I send a POST to the actions create endpoint (POST /apps/{appname}/actions)
- Then a new action should be created
- And a one-off formation should be created
```