### PR TITLE
Apps "simple mode" endpoint

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,7 +116,7 @@ ready.catch((e) => {
 });
 
 // -- apps
-routes.add.get('/apps$')
+routes.add.get('/apps(\\?[A-z0-9\\=\\?\\-\\_\\.\\&\\:]*)*$')
   .run(alamo.apps.http.list.bind(alamo.apps.http.list, pg_pool))
   .and.authorization([simple_key, jwt_key]);
 routes.add.post('/apps$')

--- a/lib/apps.js
+++ b/lib/apps.js
@@ -2,6 +2,7 @@ const assert = require('assert');
 const crypto = require('crypto');
 const fs = require('fs');
 const uuid = require('uuid');
+const url = require('url');
 const httph = require('./http_helper.js');
 const addons = require('./addons.js');
 const builds = require('./builds.js');
@@ -102,7 +103,9 @@ const insert_app = query.bind(query, fs.readFileSync('./sql/insert_app.sql').toS
 // private
 const select_app_setup_by_app = query.bind(query, fs.readFileSync('./sql/select_app_setup_by_app.sql').toString('utf8'), null);
 const select_apps_query = fs.readFileSync('./sql/select_apps.sql').toString('utf8');
+const select_apps_simple_query = fs.readFileSync('./sql/select_apps_simple.sql').toString('utf8');
 const select_apps = query.bind(query, select_apps_query, app_postgres_to_response);
+const select_apps_simple = query.bind(query, select_apps_simple_query, app_postgres_to_response);
 
 // private
 // const select_app_query = fs.readFileSync('./sql/select_app.sql').toString('utf8');
@@ -427,7 +430,18 @@ async function del(pg_pool, app_key, elevated_access, user) {
 
 // public
 async function http_list(pg_pool, req, res /* regex */) {
-  const apps = await select_apps(pg_pool, []);
+  let apps;
+  try {
+    const queryObject = url.parse(req.url, true).query;
+    if (queryObject && queryObject.simple) {
+      apps = await select_apps_simple(pg_pool, []);
+    } else {
+      apps = await select_apps(pg_pool, []);
+    }
+  } catch (err) {
+    apps = await select_apps(pg_pool, []);
+  }
+
   return httph.ok_response(res, JSON.stringify(apps));
 }
 

--- a/lib/apps.js
+++ b/lib/apps.js
@@ -72,12 +72,52 @@ function app_payload_to_response(payload) {
 }
 
 // private
+function app_simple_payload_to_response(payload) {
+  return {
+    created_at: payload.created.toISOString(),
+    description: payload.description,
+    id: payload.id,
+    labels: payload.labels,
+    maintenance: !!payload.disabled,
+    name: payload.app_key,
+    simple_name: payload.simple_name,
+    key: payload.app_key,
+    organization: {
+      id: payload.org_uuid,
+      name: payload.org_name,
+    },
+    preview: payload.preview ? {
+      id: payload.preview,
+    } : null,
+    region: {
+      id: payload.region_uuid,
+      name: payload.region_name,
+    },
+    space: {
+      id: payload.space_uuid,
+      name: payload.space_name,
+    },
+    updated_at: payload.modified.toISOString(),
+    web_url: payload.url,
+  };
+}
+
+// private
 function app_postgres_to_response(result) {
   result.app_key = `${result.app_name}-${result.space_name}`;
   result.simple_name = result.app_name;
   result.id = result.app_uuid;
   result.modified = result.updated;
   return app_payload_to_response(result);
+}
+
+// private
+function app_simple_postgres_to_response(result) {
+  result.app_key = `${result.app_name}-${result.space_name}`;
+  result.simple_name = result.app_name;
+  result.id = result.app_uuid;
+  result.modified = result.updated;
+  return app_simple_payload_to_response(result);
 }
 
 // private
@@ -105,7 +145,7 @@ const select_app_setup_by_app = query.bind(query, fs.readFileSync('./sql/select_
 const select_apps_query = fs.readFileSync('./sql/select_apps.sql').toString('utf8');
 const select_apps_simple_query = fs.readFileSync('./sql/select_apps_simple.sql').toString('utf8');
 const select_apps = query.bind(query, select_apps_query, app_postgres_to_response);
-const select_apps_simple = query.bind(query, select_apps_simple_query, app_postgres_to_response);
+const select_apps_simple = query.bind(query, select_apps_simple_query, app_simple_postgres_to_response);
 
 // private
 // const select_app_query = fs.readFileSync('./sql/select_app.sql').toString('utf8');
@@ -172,7 +212,6 @@ async function update(pg_pool, app_key, name, maintenance, description, labels, 
   hook_updated.app.maintenance = app.disabled = app.maintenance = maintenance;
   setTimeout(() => common.notify_hooks(pg_pool, app.app_uuid, 'updated', JSON.stringify(hook_updated), user || 'System'), 10);
 
-
   let errors = false;
   await Promise.all((await common.formations_exists(pg_pool, app.app_uuid)).map(async (dyno_type) => {
     try {
@@ -227,7 +266,7 @@ async function create(pg_pool, org_key, space_key, app_name, description, labels
   // determine the url for the application depending on its compliance.
   const id = uuid.v4();
   const created = new Date();
-  const url = await common.determine_app_url(pg_pool, space.tags, app_name, space.name, organization.name);
+  const uri = await common.determine_app_url(pg_pool, space.tags, app_name, space.name, organization.name);
   // create config set in alamo
   await common.alamo.config.set.create(pg_pool, app_name, space.name);
   // add the default port.
@@ -240,7 +279,7 @@ async function create(pg_pool, org_key, space_key, app_name, description, labels
     name: app_name,
     space_uuid: space.space,
     org_uuid: organization.org,
-    url,
+    url: uri,
     description,
     labels,
   }));
@@ -273,7 +312,7 @@ async function create(pg_pool, org_key, space_key, app_name, description, labels
     space_uuid: space.space,
     space_name: space.name,
     modified: created,
-    url,
+    url: uri,
     space_tags: space.tags,
   };
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akkeris-controller-api",
-  "version": "4.1.1",
+  "version": "4.2.0",
   "description": "Central API for controlling apps in akkeris",
   "main": "index.js",
   "scripts": {

--- a/sql/select_apps_simple.sql
+++ b/sql/select_apps_simple.sql
@@ -1,0 +1,27 @@
+select
+  apps.app app_uuid,
+  apps.created,
+  apps.updated,
+  apps.name app_name,
+  apps.disabled,
+  apps.description description,
+  apps.labels labels,
+  spaces.name space_name,
+  spaces.space space_uuid,
+  stacks.stack stack_uuid,
+  stacks.name stack_name,
+  regions.region region_uuid,
+  regions.name region_name,
+  organizations.name org_name,
+  organizations.org org_uuid,
+  (select preview from previews where apps.app = previews.target and previews.deleted = false limit 1) preview
+from
+  apps
+    join spaces on apps.space = spaces.space
+    join organizations on apps.org = organizations.org
+    join stacks on spaces.stack = stacks.stack and stacks.deleted = false
+    join regions on regions.region = stacks.region and regions.deleted = false
+where
+  apps.deleted = false and
+  spaces.deleted = false
+order by apps.name, spaces.name desc

--- a/sql/select_apps_simple.sql
+++ b/sql/select_apps_simple.sql
@@ -14,6 +14,7 @@ select
   regions.name region_name,
   organizations.name org_name,
   organizations.org org_uuid,
+  apps.url,
   (select preview from previews where apps.app = previews.target and previews.deleted = false limit 1) preview
 from
   apps

--- a/test/apps.js
+++ b/test/apps.js
@@ -257,6 +257,47 @@ describe('apps: ensure we can create an app, list apps, view app info and delete
     });
   });
 
+  it('Ensures we can pull all applications in simple mode.', (done) => {
+    httph.request('get', 'http://localhost:5000/apps?simple=true', alamo_headers, null, (err, data) => {
+      if (err) {
+        console.error(err);
+      }
+      expect(err).to.be.null;
+      expect(data).to.be.a('string');
+      const appsobj = JSON.parse(data);
+      expect(appsobj).to.be.an('array');
+      appsobj.forEach((appobj) => {
+        if (appobj.name === 'alamotestapp-default') {
+          expect(appobj).to.be.an('object');
+          expect(appobj.archived_at).to.be.undefined;
+          expect(appobj.buildpack_provided_description).to.be.undefined;
+          expect(appobj.build_stack).to.be.undefined;
+          expect(appobj.build_stack.id).to.be.undefined;
+          expect(appobj.build_stack.name).to.be.undefined;
+          expect(appobj.created_at).to.be.a('string');
+          expect(appobj.id).to.be.a('string');
+          expect(appobj.maintenance).to.equal(false);
+          expect(appobj.name).to.equal('alamotestapp-default');
+          expect(appobj.key).to.equal('alamotestapp-default');
+          expect(appobj.owner).to.be.undefined;
+          expect(appobj.organization).to.be.an('object');
+          expect(appobj.organization.name).to.equal('test');
+          expect(appobj.region).to.be.an('object');
+          expect(appobj.region.name).to.be.a('string');
+          expect(appobj.released_at).to.be.undefined;
+          expect(appobj.repo_size).to.be.undefined;
+          expect(appobj.slug_size).to.be.undefined;
+          expect(appobj.space).to.be.an('object');
+          expect(appobj.space.name).to.equal('default');
+          expect(appobj.stack).to.be.undefined;
+          expect(appobj.updated_at).to.be.a('string');
+          expect(appobj.web_url).to.contain(`https://alamotestapp${process.env.ALAMO_BASE_DOMAIN}`);
+          done();
+        }
+      });
+    });
+  });
+
   it('Ensures we cannot delete an app in a socs/prod space.', (done) => {
     const new_headers = JSON.parse(JSON.stringify(alamo_headers));
     delete new_headers['x-elevated-access'];

--- a/test/apps.js
+++ b/test/apps.js
@@ -272,8 +272,6 @@ describe('apps: ensure we can create an app, list apps, view app info and delete
           expect(appobj.archived_at).to.be.undefined;
           expect(appobj.buildpack_provided_description).to.be.undefined;
           expect(appobj.build_stack).to.be.undefined;
-          expect(appobj.build_stack.id).to.be.undefined;
-          expect(appobj.build_stack.name).to.be.undefined;
           expect(appobj.created_at).to.be.a('string');
           expect(appobj.id).to.be.a('string');
           expect(appobj.maintenance).to.equal(false);


### PR DESCRIPTION
Add the ability to pass `?simple=true` to the end of the `/apps` endpoint. This reduces the amount of information included with each app when fetching them all.

This is especially useful with the UI, where we don't need things like each app's formation info in the main app list screen. It reduces load times immensely since the controller can use a much simpler SQL query.

Bumped package version to `4.2.0` because I'm changing the `/apps` endpoint, even though this still should be backwards compatible (any existing client will continue to work with no issues).