### PR TITLE
Add PagerDuty hook formatter

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ To disable custom formatting for outgoing webhooks set these to true.
 * `WEBHOOK_DISABLE_CIRCLECI` - If set to `true` disable auto-formatting outgoing webhooks for CircleCI Jobs.
 * `WEBHOOK_DISABLE_SLACK` - If set to `true` disable auto-formatting outgoing webhooks for Slack Channel Notifications.
 * `WEBHOOK_DISABLE_OPSGENIE` - If set to `true` disable auto-formatting outgoing webhooks for OpsGenie Alerts.
+* `WEBHOOK_DISABLE_PAGERDUTY` - If set to `true` disable auto-formatting outgoing webhooks for PagerDuty Alerts.
 * `WEBHOOK_DISABLE_ROLLBAR` - If set to `true` disable auto-formatting outgoing release webhooks for notifying Rollbar of deployments.
 
 ## Installing ##

--- a/lib/common.js
+++ b/lib/common.js
@@ -562,6 +562,7 @@ const hook_types = [
   require('./hook-types/opsgenie.js'),
   require('./hook-types/rollbar.js'),
   require('./hook-types/slack.js'),
+  require('./hook-types/pagerduty.js'),
   require('./hook-types/https.js'), // THIS MUST BE LAST, order matters here.
 ].filter((x) => x.enabled());
 

--- a/lib/hook-types/microsoft-teams.js
+++ b/lib/hook-types/microsoft-teams.js
@@ -12,7 +12,7 @@ function test(hook_url) {
 
 function fire(id, hook_url, type, incoming, hmac, headers = {}, token = null) {
   if (!test(hook_url)) {
-    throw new Error('unable to fire webhook:', hook_url, 'is not a valid slack endpoint');
+    throw new Error('unable to fire webhook:', hook_url, 'is not a valid Teams endpoint');
   }
   // See: https://docs.microsoft.com/en-us/outlook/actionable-messages/send-via-connectors
   // TODO: populate with different formatting depending on incoming message.

--- a/lib/hook-types/opsgenie.js
+++ b/lib/hook-types/opsgenie.js
@@ -21,7 +21,7 @@ function to_string_map(input) {
 
 function fire(id, hook_url, type, incoming, hmac, headers = {}, token = null) {
   if (!test(hook_url)) {
-    throw new Error('unable to fire webhook:', hook_url, 'is not a valid opsgenie');
+    throw new Error('unable to fire webhook:', hook_url, 'is not a valid opsgenie endpoint');
   }
   const payload = {
     source: `${incoming.app.name}-${incoming.space.name}`,

--- a/lib/hook-types/pagerduty.js
+++ b/lib/hook-types/pagerduty.js
@@ -1,0 +1,93 @@
+// Do not include anything from the rest of the project here
+// including common.js.
+
+const url = require('url');
+const https = require('./https.js');
+
+const ALLOWED_SEVERITY = ['critical', 'warning', 'error', 'info'];
+
+// PagerDuty API: https://developer.pagerduty.com/api-reference/b3A6Mjc0ODI2Nw-send-an-event-to-pager-duty
+
+// /v2/enqueue - Send Event
+// /v2/change/enqueue - Send Change Event
+// Integration key should be and severity level can be provided after the endpoint
+// Severity level should be one of 'critical, warning, error, info'
+//   e.g. https://events.pagerduty.com/v2/enqueue/?key=737ea619db564d41bd9824063e1f6b08&severity=warning
+
+function test(hook_url) {
+  if (
+    hook_url.toLowerCase().startsWith('https://events.pagerduty.com/v2/enqueue/?')
+    || hook_url.toLowerCase().startsWith('https://events.pagerduty.com/v2/change/enqueue/?')
+  ) {
+    try {
+      return (new URL(hook_url)).searchParams.has('integration_key'); // Needs to at least include the integration key for this to work
+    } catch (err) {
+      return false;
+    }
+  }
+  return false;
+}
+
+function to_string_map(input) {
+  const out = {};
+  Object.keys(input).forEach((x) => {
+    out[x] = JSON.stringify(input[x], null, 2);
+  });
+  return out;
+}
+
+function clean_forward_slash(uri) {
+  if (!uri) {
+    return uri;
+  }
+  if (uri[uri.length - 1] === '/') {
+    uri = uri.substring(0, uri.length - 1);
+  }
+  if (!uri.startsWith('http')) {
+    uri = `https://${uri}`;
+  }
+  return uri;
+}
+
+function fire(id, hook_url, type, incoming, hmac, headers = {}, token = null) {
+  if (!test(hook_url)) {
+    throw new Error('unable to fire webhook:', hook_url, 'is not a valid PagerDuty endpoint');
+  }
+
+  const fire_type = hook_url.toLowerCase().includes('change/enqueue') ? 'change' : 'event';
+  const search_params = (new url.URL(hook_url.toLowerCase())).searchParams;
+  const severity = (
+    search_params.has('severity')
+    && ALLOWED_SEVERITY.includes(search_params.get('severity').toLowerCase())
+  ) ? search_params.get('severity').toLowerCase() : 'critical';
+
+  const payload = {
+    payload: {
+      // Summary of event, used to generate summaries and titles of alerts
+      summary: `${incoming.action} event fired on ${incoming.app.name}-${incoming.space.name}`,
+      // Unique location of the affected system, preferably a hostname or FQDN
+      source: `${incoming.app.name}-${incoming.space.name}`,
+      // Additional details about the event and affected system
+      custom_details: to_string_map(incoming),
+    },
+    routing_key: search_params.get('integration_key'),
+  };
+
+  if (fire_type === 'event') {
+    payload.event_action = 'trigger';
+    payload.client = 'Akkeris';
+    payload.client_url = clean_forward_slash(process.env.AKKERIS_UI_URL);
+    payload.payload.severity = severity;
+  }
+
+  return https.fire(id, hook_url, type, payload, hmac, headers, token);
+}
+
+module.exports = {
+  test,
+  fire,
+  enabled: () => (!process.env.WEBHOOK_DISABLE_PAGERDUTY),
+  name: 'PagerDuty',
+  description: 'Send a PagerDuty alert on an event.',
+  format: 'https://events.pagerduty.com/v2/(enqueue|change/enqueue)/?integration_key=<key>&severity=<severity>',
+};

--- a/lib/hook-types/pagerduty.js
+++ b/lib/hook-types/pagerduty.js
@@ -31,7 +31,7 @@ function test(hook_url) {
 function to_string_map(input) {
   const out = {};
   Object.keys(input).forEach((x) => {
-    out[x] = JSON.stringify(input[x], null, 2);
+    out[x] = JSON.stringify(input[x]);
   });
   return out;
 }

--- a/lib/hook-types/pagerduty.js
+++ b/lib/hook-types/pagerduty.js
@@ -8,7 +8,7 @@ const ALLOWED_SEVERITY = ['critical', 'warning', 'error', 'info'];
 
 // PagerDuty API: https://developer.pagerduty.com/api-reference/b3A6Mjc0ODI2Nw-send-an-event-to-pager-duty
 
-// /v2/enqueue - Send Event
+// /v2/enqueue - Send Alert Event
 // /v2/change/enqueue - Send Change Event
 // Integration key should be and severity level can be provided after the endpoint
 // Severity level should be one of 'critical, warning, error, info'
@@ -54,7 +54,7 @@ function fire(id, hook_url, type, incoming, hmac, headers = {}, token = null) {
     throw new Error('unable to fire webhook:', hook_url, 'is not a valid PagerDuty endpoint');
   }
 
-  const fire_type = hook_url.toLowerCase().includes('change/enqueue') ? 'change' : 'event';
+  const fire_type = hook_url.toLowerCase().includes('change/enqueue') ? 'change' : 'alert';
   const search_params = (new url.URL(hook_url.toLowerCase())).searchParams;
   const severity = (
     search_params.has('severity')
@@ -73,7 +73,7 @@ function fire(id, hook_url, type, incoming, hmac, headers = {}, token = null) {
     routing_key: search_params.get('integration_key'),
   };
 
-  if (fire_type === 'event') {
+  if (fire_type === 'alert') {
     payload.event_action = 'trigger';
     payload.client = 'Akkeris';
     payload.client_url = clean_forward_slash(process.env.AKKERIS_UI_URL);

--- a/lib/hook-types/pagerduty.js
+++ b/lib/hook-types/pagerduty.js
@@ -12,7 +12,7 @@ const ALLOWED_SEVERITY = ['critical', 'warning', 'error', 'info'];
 // /v2/change/enqueue - Send Change Event
 // Integration key should be and severity level can be provided after the endpoint
 // Severity level should be one of 'critical, warning, error, info'
-//   e.g. https://events.pagerduty.com/v2/enqueue?key=737ea619db564d41bd9824063e1f6b08&severity=warning
+//   e.g. https://events.pagerduty.com/v2/enqueue?integration_key=737ea619db564d41bd9824063e1f6b08&severity=warning
 
 function test(hook_url) {
   if (

--- a/lib/hook-types/pagerduty.js
+++ b/lib/hook-types/pagerduty.js
@@ -12,12 +12,12 @@ const ALLOWED_SEVERITY = ['critical', 'warning', 'error', 'info'];
 // /v2/change/enqueue - Send Change Event
 // Integration key should be and severity level can be provided after the endpoint
 // Severity level should be one of 'critical, warning, error, info'
-//   e.g. https://events.pagerduty.com/v2/enqueue/?key=737ea619db564d41bd9824063e1f6b08&severity=warning
+//   e.g. https://events.pagerduty.com/v2/enqueue?key=737ea619db564d41bd9824063e1f6b08&severity=warning
 
 function test(hook_url) {
   if (
-    hook_url.toLowerCase().startsWith('https://events.pagerduty.com/v2/enqueue/?')
-    || hook_url.toLowerCase().startsWith('https://events.pagerduty.com/v2/change/enqueue/?')
+    hook_url.toLowerCase().startsWith('https://events.pagerduty.com/v2/enqueue?')
+    || hook_url.toLowerCase().startsWith('https://events.pagerduty.com/v2/change/enqueue?')
   ) {
     try {
       return (new URL(hook_url)).searchParams.has('integration_key'); // Needs to at least include the integration key for this to work
@@ -89,5 +89,5 @@ module.exports = {
   enabled: () => (!process.env.WEBHOOK_DISABLE_PAGERDUTY),
   name: 'PagerDuty',
   description: 'Send a PagerDuty alert on an event.',
-  format: 'https://events.pagerduty.com/v2/(enqueue|change/enqueue)/?integration_key=<key>&severity=<severity>',
+  format: 'https://events.pagerduty.com/v2/(enqueue|change/enqueue)?integration_key=<key>&severity=<severity>',
 };


### PR DESCRIPTION
Add a formatter to send PagerDuty alerts from hooks.

Can send both `events` and `change events` (see the [PagerDuty API](https://developer.pagerduty.com/api-reference/b3A6Mjc0ODI2Ng-send-change-events-to-the-pager-duty-events-api)) depending on which URI you provide for the hook

Need to provide integration key as a url parameter (`integration_key`). Also can optionally specify the alert severity with the `severity` parameter for the `events` API.