### PR TITLE
Add ability to trigger fresh build from Git source

### DIFF
--- a/index.js
+++ b/index.js
@@ -238,6 +238,9 @@ routes.add.get('/apps/([A-z0-9\\-\\_\\.]+)/builds/auto/github$')
 routes.add.delete('/apps/([A-z0-9\\-\\_\\.]+)/builds/auto/github$')
   .run(alamo.git.http.autobuild.delete.bind(alamo.git.http.autobuild.delete, pg_pool))
   .and.authorization([simple_key, jwt_key]);
+routes.add.post('/apps/([A-z0-9\\-\\_\\.]+)/builds/auto/github/trigger$')
+  .run(alamo.git.http.manual_build.create.bind(alamo.git.http.manual_build.create, pg_pool))
+  .and.authorization([simple_key, jwt_key]);
 
 // -- Github callbacks, no auth but authenticated through
 routes.add.post('/apps/([A-z0-9\\-\\_\\.]+)/builds/auto/github$')

--- a/lib/git.js
+++ b/lib/git.js
@@ -416,14 +416,16 @@ async function pull_request_webhook_received(pg_pool, app, payload) {
       // DO NOT DELETE app, DELETE THE PREVIEW APP app CREATED. FIRST MAKE SURE
       // THE APP DELETE HAPPENS THEN DELETE THE PREVIEW RECORD.
 
-      // If the app is in the process of being setup then 
+      // If the app is in the process of being setup then
       // wait for 5 seconds and try again with a maximum of 12 retries
-      for(let i=0; i < 12; i++) {
+      for (let i = 0; i < 12; i++) {
         try {
-          await apps.check_app_delete(pg_pool, {"app_uuid":preview_apps[0].target}, {"tags":app.space_tags, "space_uuid":app.space_uuid});
+          // eslint-disable-next-line
+          await apps.check_app_delete(pg_pool, { app_uuid: preview_apps[0].target }, { tags: app.space_tags, space_uuid: app.space_uuid });
           break;
         } catch (e) {
           console.log('Warning: waiting to remove preview app', preview_apps[0].target, 'due to', e, 'waiting 5 seconds.');
+          // eslint-disable-next-line
           await new Promise((res, rej) => setTimeout(res, 5000));
         }
       }
@@ -696,7 +698,7 @@ async function add_deployment_to_build(
 }
 
 async function get_token(pg_pool, app_uuid) {
-  // If we're a preview app we need to fetch our authorizaiton from our source app
+  // If we're a preview app we need to fetch our authorization from our source app
   let authorizations = await select_validation_token(pg_pool, [app_uuid]);
   const source_app = await previews.source_app(pg_pool, app_uuid);
   if (source_app !== null) {
@@ -896,6 +898,43 @@ async function update_deployments_for_release(pg_pool, payload) {
   }
 }
 
+// Create a fresh build from the Github source
+async function http_github_create_manual_build(pg_pool, req, res, regex) {
+  const app_key = http_help.first_match(req.url, regex);
+  const app = await common.app_exists(pg_pool, app_key);
+  const space = await common.space_exists(pg_pool, app.space_name);
+
+  if (!(req.headers['x-elevated-access'] === 'true' && req.headers['x-username'])
+    && (space.tags.indexOf('compliance=socs') > -1 || space.tags.indexOf('compliance=prod') > -1)) {
+    throw new common.NotAllowedError('Arbitrary builds on this application can only be created by administrators.');
+  }
+
+  let auto_build;
+  try {
+    auto_build = await auto_builds.get(pg_pool, app.app_uuid);
+  } catch (err) {
+    if (err instanceof common.NotFoundError) {
+      throw new common.BadRequestError('The specified app does not have an auto-build source configured.');
+    }
+    throw err;
+  }
+
+  const token = await get_token(pg_pool, app.app_uuid);
+  if (token === null) {
+    throw new common.InternalServerError('The app does not have valid authorization on the source repository!');
+  }
+
+  await create_build_from_scm(pg_pool, app.app_uuid, auto_build.repo, auto_build.branch, token)
+    .catch((e) => {
+      if (process.env.TEST_MODE) {
+        return; // swallow errors during tests since we dont have a valid github token.
+      }
+      console.error('Failed to generate manual SCM build: ', e);
+      throw new common.InternalServerError('Failed to generate build: Please contact your local maytag man for assistance.');
+    });
+  return http_help.created_response(res, '{"status":"successful"}');
+}
+
 function init(pg_pool) {
   common.lifecycle.on('build', update_commit_status_for_build.bind(null, pg_pool));
   common.lifecycle.on('build', create_deployments_for_build.bind(null, pg_pool));
@@ -913,6 +952,9 @@ module.exports = {
       get: http_github_get_auto_build,
       delete: http_github_delete_auto_build,
       create: http_github_create_auto_build,
+    },
+    manual_build: {
+      create: http_github_create_manual_build,
     },
   },
 };


### PR DESCRIPTION
This adds an endpoint to trigger a fresh build from the auto-build source, similar to how the app has a new build after the auto-build source is attached.