### PR TITLE
COBRA-5020: BETA feature to allow additional (in-cluster only) ports on web dynos

### DIFF
--- a/lib/common.js
+++ b/lib/common.js
@@ -512,6 +512,7 @@ async function check_deployment_features(pg_pool, app_uuid, dyno_type) {
       'csp-media': await feature_enabled(pg_pool, app_uuid, 'csp-media'),
       'csp-unsafe': await feature_enabled(pg_pool, app_uuid, 'csp-unsafe'),
       'csp-embedded': await feature_enabled(pg_pool, app_uuid, 'csp-embedded'),
+      'container-ports': await feature_enabled(pg_pool, app_uuid, 'container-ports'),
     };
   }
   return {

--- a/lib/features.js
+++ b/lib/features.js
@@ -126,7 +126,7 @@ const available_features = [
     enabled: false, /* Must always be false! */
   },
   {
-    description: 'Add additional exposed ports to the web dyno (reachable in-cluster only) via a comma-separated list of port values specified in the CONTAINER_PORTS config var',
+    description: '(BETA) Add additional exposed ports to the web dyno (reachable in-cluster only) via a comma-separated list of port values specified in the CONTAINER_PORTS config var',
     doc_url: '/features/container-ports',
     id: 'bf51e09c-3965-4186-91d5-9b1e4e1f4b61',
     state: 'public',

--- a/lib/features.js
+++ b/lib/features.js
@@ -125,6 +125,16 @@ const available_features = [
     feedback_email: process.env.SUPPORT_EMAIL,
     enabled: false, /* Must always be false! */
   },
+  {
+    description: 'Add additional exposed ports to the web dyno (reachable in-cluster only) via a comma-separated list of port values specified in the CONTAINER_PORTS config var',
+    doc_url: '/features/container-ports',
+    id: 'bf51e09c-3965-4186-91d5-9b1e4e1f4b61',
+    state: 'public',
+    name: 'container-ports',
+    display_name: 'In-cluster Container Ports',
+    feedback_email: process.env.SUPPORT_EMAIL,
+    enabled: false, /* Must always be false! */
+  },
 ];
 
 function to_response(frecord) {


### PR DESCRIPTION
This adds a feature flag that enables the ability to specify additional exposed ports through an environment variable when the "container-ports" feature is enabled on an application. These ports are NOT exposed outside the cluster, but available on an internal ClusterIP service.

While this functionality is being beta tested, the additional ports can be specified through a special environment variable / "config var" of "CONTAINER_PORTS". This should be set to a comma-separated list of valid integers that will be exposed on the pod and only available to other applications and services in the same cluster/region.

Once this functionality has been tested and verified to be stable and production ready, the code will be changed to remove the 'feature' and instead add a new property of a web dyno that will allow for specification of additional ports.

This code requires that the associated pull requests on the controller-api and service-watcher-istio be merged as well for it to work properly - the region-api so that the new Kubernetes service is created and the ports are exposed on the application deployment/pod, and the service-watcher-istio so that new virtualservices are not created for the container port service.

region-api PR: https://github.com/akkeris/region-api/pull/390
service-watcher-istio PR: https://github.com/akkeris/service-watcher-istio/pull/6